### PR TITLE
feat: add page loader with light/dark mode support

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -8,6 +8,7 @@ import { SpeedInsights } from "@vercel/speed-insights/next";
 
 import "@/app/globals.css";
 import { ReactNode } from "react";
+import { PageLoader } from "@/components/PageLoader";
 
 const cormorant = Cormorant_Garamond({
   subsets: ["latin"],
@@ -43,6 +44,7 @@ export default async function LocaleLayout({
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
       </Head>
       <body className={cormorant.className}>
+        <PageLoader />
         <NextIntlClientProvider locale={locale} messages={messages}>
           {children}
         </NextIntlClientProvider>

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -1,7 +1,6 @@
 import { NextIntlClientProvider } from "next-intl";
 import { getMessages } from "next-intl/server";
-import type { Metadata } from "next";
-import Head from "next/head";
+import type { Metadata, Viewport } from "next";
 import { Cormorant_Garamond } from "next/font/google";
 import { Analytics } from "@vercel/analytics/next";
 import { SpeedInsights } from "@vercel/speed-insights/next";
@@ -23,6 +22,11 @@ export const metadata: Metadata = {
     "The personal website of Paul Cooper, a London based Front End Developer working at Human Made Machine",
 };
 
+export const viewport: Viewport = {
+  width: "device-width",
+  initialScale: 1,
+};
+
 interface LocaleLayoutProps {
   children: ReactNode;
   params: Promise<{
@@ -40,9 +44,6 @@ export default async function LocaleLayout({
 
   return (
     <html lang={locale}>
-      <Head>
-        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-      </Head>
       <body className={cormorant.className}>
         <PageLoader />
         <NextIntlClientProvider locale={locale} messages={messages}>

--- a/src/components/PageLoader.tsx
+++ b/src/components/PageLoader.tsx
@@ -44,37 +44,53 @@ function FlagCircle({ locale }: { locale: string }) {
 
       {locale === "en" && (
         <g clipPath={`url(#${clipId})`}>
-          {/* Union Jack */}
-          <rect x="4" y="4" width="36" height="36" fill="#012169" />
-          {/* White saltire (×) */}
-          <rect x="4" y="20" width="36" height="4" fill="white" transform="rotate(45 22 22)" />
-          <rect x="4" y="20" width="36" height="4" fill="white" transform="rotate(-45 22 22)" />
-          {/* Red saltire (×, narrower, centred) */}
-          <rect x="4" y="21" width="36" height="2" fill="#C8102E" transform="rotate(45 22 22)" />
-          <rect x="4" y="21" width="36" height="2" fill="#C8102E" transform="rotate(-45 22 22)" />
-          {/* White cross (+) */}
-          <rect x="4" y="18.5" width="36" height="7" fill="white" />
-          <rect x="18.5" y="4" width="7" height="36" fill="white" />
-          {/* Red cross (+) */}
-          <rect x="4" y="20" width="36" height="4" fill="#C8102E" />
-          <rect x="20" y="4" width="4" height="36" fill="#C8102E" />
+          {/* White field (base) */}
+          <rect x="0" y="0" width="44" height="44" fill="white" />
+          {/*
+           * Paths ported from source SVG (25 000×25 000 space, y-up).
+           * Combined transform → 44×44 px:
+           *   x_out =  0.00176 · x_path
+           *   y_out = −0.00176 · y_path + 44
+           */}
+          <g transform="matrix(0.00176,0,0,-0.00176,0,44)">
+            {/* Blue field — 8 triangles */}
+            <path d="m 10365.2,24970.5 v -8916 L 346.258,25000 Z" fill="#273376" />
+            <path d="M -3125,22896.9 5760.08,15343.6 H -3125 Z" fill="#273376" />
+            <path d="M -3125,9699.2 V 783.301 L 6893.93,9728.8 Z" fill="#273376" />
+            <path d="M 10365.2,7625.7 1480.11,72.4023 h 8885.09 z" fill="#273376" />
+            <path d="m 14623.7,24970.5 v -8916 l 10019,8945.5 z" fill="#273376" />
+            <path d="m 28113.9,22896.9 -8885.1,-7553.3 h 8885.1 z" fill="#273376" />
+            <path d="M 14623.7,101.898 V 9017.9 L 24642.7,72.4023 Z" fill="#273376" />
+            {/* Red cross */}
+            <path
+              d="M 14016.3,14662.3 V 25000 H 10921.7 V 14662.3 H -3113.91 V 10337.7 H 10921.7 V 0 h 3094.6 V 10337.7 H 28125 v 4324.6 H 14016.3"
+              fill="#CC2628"
+            />
+            {/* Red counter-changed saltire — 4 offset slivers */}
+            <path d="M 8610.09,15343.6 -3100.66,25000 V 23876.9 L 7195.33,15343.6 h 1414.76" fill="#CC2628" />
+            <path d="M 44.8789,72.4023 10340.8,8605.6 V 9728.8 L -1369.89,72.4023 H 44.8789" fill="#CC2628" />
+            <path d="M 28089.6,23876.9 V 25000 L 16378.8,15343.6 h 1414.8 l 10296,8533.3" fill="#CC2628" />
+            <path d="M 16378.8,9728.8 28089.6,72.4023 V 1195.5 l -10296,8533.3 h -1414.8" fill="#CC2628" />
+            {/* Final blue triangle — drawn over red to complete counter-change in lower-right */}
+            <path d="m 28113.9,2175.4 -8885.1,7553.4 h 8885.1 z" fill="#273376" />
+          </g>
         </g>
       )}
 
       {locale === "fr" && (
         <g clipPath={`url(#${clipId})`}>
           {/* French tricolour — vertical */}
-          <rect x="4" y="4" width="36" height="36" fill="#ED2939" />
-          <rect x="4" y="4" width="24" height="36" fill="white" />
-          <rect x="4" y="4" width="12" height="36" fill="#002395" />
+          <rect x="0" y="0" width="44" height="44" fill="#ED2939" />
+          <rect x="0" y="0" width="29" height="44" fill="white" />
+          <rect x="0" y="0" width="15" height="44" fill="#002395" />
         </g>
       )}
 
       {locale === "es" && (
         <g clipPath={`url(#${clipId})`}>
           {/* Spanish flag — horizontal bands */}
-          <rect x="4" y="4" width="36" height="36" fill="#AA151B" />
-          <rect x="4" y="13" width="36" height="18" fill="#F1BF00" />
+          <rect x="0" y="0" width="44" height="44" fill="#AA151B" />
+          <rect x="0" y="13" width="44" height="18" fill="#F1BF00" />
         </g>
       )}
     </svg>
@@ -142,7 +158,7 @@ export function PageLoader() {
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
           exit={{ opacity: 0 }}
-          transition={{ duration: 0.35, ease: "easeInOut" }}
+          transition={{ duration: 0.42, ease: "easeInOut" }}
           style={{
             position: "fixed",
             inset: 0,
@@ -153,8 +169,28 @@ export function PageLoader() {
             backgroundColor: "var(--colour-bg)",
           }}
         >
-          {/* Fixed-size wrapper so spinner and flag crossfade in place */}
-          <div style={{ position: "relative", width: 44, height: 44 }}>
+          {/*
+           * Icon wrapper — scales in with a soft spring overshoot on enter,
+           * and gently scales back out on exit. Spinner and flag both inherit
+           * this, so the whole icon breathes in/out with the overlay.
+           */}
+          <motion.div
+            style={{ position: "relative", width: 44, height: 44 }}
+            variants={{
+              initial: { scale: 0.93 },
+              animate: {
+                scale: 1,
+                transition: { duration: 0.45, ease: [0.34, 1.56, 0.64, 1] },
+              },
+              exit: {
+                scale: 0,
+                transition: { duration: 0.38, ease: [0.4, 0, 0.6, 1] },
+              },
+            }}
+            initial="initial"
+            animate="animate"
+            exit="exit"
+          >
             <AnimatePresence initial={false}>
               {phase === "spinner" && (
                 <motion.div
@@ -163,7 +199,7 @@ export function PageLoader() {
                   initial={{ opacity: 0 }}
                   animate={{ opacity: 1 }}
                   exit={{ opacity: 0 }}
-                  transition={{ duration: 0.2, ease: "easeInOut" }}
+                  transition={{ duration: 0.22, ease: "easeInOut" }}
                 >
                   <svg
                     width="44"
@@ -213,16 +249,23 @@ export function PageLoader() {
                 <motion.div
                   key="flag"
                   style={{ position: "absolute", inset: 0 }}
-                  initial={{ opacity: 0, scale: 0.7 }}
-                  animate={{ opacity: 1, scale: 1 }}
-                  exit={{ opacity: 0, scale: 0.95 }}
-                  transition={{ duration: 0.35, ease: [0.34, 1.56, 0.64, 1] }}
+                  initial={{ opacity: 0, scale: 0.72 }}
+                  animate={{
+                    opacity: 1,
+                    scale: 1,
+                    transition: { duration: 0.38, ease: [0.34, 1.56, 0.64, 1] },
+                  }}
+                  exit={{
+                    opacity: 0,
+                    scale: 0.92,
+                    transition: { duration: 0.55, ease: "easeInOut" },
+                  }}
                 >
                   <FlagCircle locale={flagLocale} />
                 </motion.div>
               )}
             </AnimatePresence>
-          </div>
+          </motion.div>
         </motion.div>
       )}
     </AnimatePresence>

--- a/src/components/PageLoader.tsx
+++ b/src/components/PageLoader.tsx
@@ -4,31 +4,141 @@ import { useEffect, useRef, useState } from "react";
 import { AnimatePresence, motion } from "motion/react";
 import { usePathname } from "next/navigation";
 
+type Phase = "spinner" | "flag" | "idle";
+
+function getLocale(pathname: string): string {
+  const match = pathname.match(/^\/(fr|es)(\/|$)/);
+  return match ? match[1] : "en";
+}
+
+function FlagCircle({ locale }: { locale: string }) {
+  const clipId = `loader-flag-clip-${locale}`;
+  return (
+    <svg
+      width="44"
+      height="44"
+      viewBox="0 0 44 44"
+      fill="none"
+      style={{ color: "var(--colour-text-primary)" }}
+    >
+      <defs>
+        <clipPath id={clipId}>
+          <circle cx="22" cy="22" r="18" />
+        </clipPath>
+      </defs>
+
+      {/* Faint track — matches the spinner */}
+      <circle
+        cx="22"
+        cy="22"
+        r="18"
+        stroke="currentColor"
+        strokeWidth="1"
+        opacity="0.12"
+      />
+
+      {locale === "en" && (
+        <g clipPath={`url(#${clipId})`}>
+          {/* Union Jack */}
+          <rect x="4" y="4" width="36" height="36" fill="#012169" />
+          {/* White saltire (×) */}
+          <rect
+            x="4" y="20" width="36" height="4"
+            fill="white"
+            transform="rotate(45 22 22)"
+          />
+          <rect
+            x="4" y="20" width="36" height="4"
+            fill="white"
+            transform="rotate(-45 22 22)"
+          />
+          {/* Red saltire (×, narrower, centred) */}
+          <rect
+            x="4" y="21" width="36" height="2"
+            fill="#C8102E"
+            transform="rotate(45 22 22)"
+          />
+          <rect
+            x="4" y="21" width="36" height="2"
+            fill="#C8102E"
+            transform="rotate(-45 22 22)"
+          />
+          {/* White cross (+) */}
+          <rect x="4" y="18.5" width="36" height="7" fill="white" />
+          <rect x="18.5" y="4" width="7" height="36" fill="white" />
+          {/* Red cross (+) */}
+          <rect x="4" y="20" width="36" height="4" fill="#C8102E" />
+          <rect x="20" y="4" width="4" height="36" fill="#C8102E" />
+        </g>
+      )}
+
+      {locale === "fr" && (
+        <g clipPath={`url(#${clipId})`}>
+          {/* French tricolour — vertical */}
+          <rect x="4" y="4" width="36" height="36" fill="#ED2939" />
+          <rect x="4" y="4" width="24" height="36" fill="white" />
+          <rect x="4" y="4" width="12" height="36" fill="#002395" />
+        </g>
+      )}
+
+      {locale === "es" && (
+        <g clipPath={`url(#${clipId})`}>
+          {/* Spanish flag — horizontal bands */}
+          <rect x="4" y="4" width="36" height="36" fill="#AA151B" />
+          <rect x="4" y="13" width="36" height="18" fill="#F1BF00" />
+        </g>
+      )}
+    </svg>
+  );
+}
+
 export function PageLoader() {
-  const [isLoading, setIsLoading] = useState(true);
+  const [phase, setPhase] = useState<Phase>("spinner");
+  const [flagLocale, setFlagLocale] = useState("en");
   const pathname = usePathname();
+  const prevLocale = useRef("");
   const isInitialized = useRef(false);
 
-  // Hide after initial page load
+  // Initial page load — show spinner then hide
   useEffect(() => {
+    prevLocale.current = getLocale(pathname);
     const t = setTimeout(() => {
-      setIsLoading(false);
+      setPhase("idle");
       isInitialized.current = true;
     }, 1400);
     return () => clearTimeout(t);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // Show on route transitions
+  // Route / locale transitions
   useEffect(() => {
     if (!isInitialized.current) return;
-    setIsLoading(true);
-    const t = setTimeout(() => setIsLoading(false), 700);
-    return () => clearTimeout(t);
+
+    const newLocale = getLocale(pathname);
+    const isLocaleChange = prevLocale.current !== newLocale;
+    prevLocale.current = newLocale;
+
+    if (isLocaleChange) {
+      // Locale switch: spinner → flag → hide
+      setFlagLocale(newLocale);
+      setPhase("spinner");
+      const t1 = setTimeout(() => setPhase("flag"), 650);
+      const t2 = setTimeout(() => setPhase("idle"), 1250);
+      return () => {
+        clearTimeout(t1);
+        clearTimeout(t2);
+      };
+    } else {
+      // Regular route change: spinner → hide
+      setPhase("spinner");
+      const t = setTimeout(() => setPhase("idle"), 700);
+      return () => clearTimeout(t);
+    }
   }, [pathname]);
 
   return (
     <AnimatePresence>
-      {isLoading && (
+      {phase !== "idle" && (
         <motion.div
           key="page-loader"
           initial={{ opacity: 0 }}
@@ -45,49 +155,76 @@ export function PageLoader() {
             backgroundColor: "var(--colour-bg)",
           }}
         >
-          <svg
-            width="44"
-            height="44"
-            viewBox="0 0 44 44"
-            fill="none"
-            style={{ color: "var(--colour-text-primary)" }}
-          >
-            {/* Faint track */}
-            <circle
-              cx="22"
-              cy="22"
-              r="18"
-              stroke="currentColor"
-              strokeWidth="1"
-              opacity="0.12"
-            />
-            {/* Rotating arc */}
-            <motion.g
-              style={{ transformOrigin: "22px 22px" }}
-              animate={{ rotate: 360 }}
-              transition={{
-                duration: 1.4,
-                ease: "linear",
-                repeat: Infinity,
-              }}
-            >
-              <motion.circle
-                cx="22"
-                cy="22"
-                r="18"
-                stroke="currentColor"
-                strokeWidth="1.5"
-                strokeLinecap="round"
-                initial={{ pathLength: 0.2 }}
-                animate={{ pathLength: [0.15, 0.75, 0.15] }}
-                transition={{
-                  duration: 1.4,
-                  ease: "easeInOut",
-                  repeat: Infinity,
-                }}
-              />
-            </motion.g>
-          </svg>
+          {/* Fixed-size wrapper so spinner and flag can crossfade in place */}
+          <div style={{ position: "relative", width: 44, height: 44 }}>
+            <AnimatePresence initial={false}>
+              {phase === "spinner" && (
+                <motion.div
+                  key="spinner"
+                  style={{ position: "absolute", inset: 0 }}
+                  initial={{ opacity: 0 }}
+                  animate={{ opacity: 1 }}
+                  exit={{ opacity: 0 }}
+                  transition={{ duration: 0.2, ease: "easeInOut" }}
+                >
+                  <svg
+                    width="44"
+                    height="44"
+                    viewBox="0 0 44 44"
+                    fill="none"
+                    style={{ color: "var(--colour-text-primary)" }}
+                  >
+                    <circle
+                      cx="22"
+                      cy="22"
+                      r="18"
+                      stroke="currentColor"
+                      strokeWidth="1"
+                      opacity="0.12"
+                    />
+                    <motion.g
+                      style={{ transformOrigin: "22px 22px" }}
+                      animate={{ rotate: 360 }}
+                      transition={{
+                        duration: 1.4,
+                        ease: "linear",
+                        repeat: Infinity,
+                      }}
+                    >
+                      <motion.circle
+                        cx="22"
+                        cy="22"
+                        r="18"
+                        stroke="currentColor"
+                        strokeWidth="1.5"
+                        strokeLinecap="round"
+                        initial={{ pathLength: 0.2 }}
+                        animate={{ pathLength: [0.15, 0.75, 0.15] }}
+                        transition={{
+                          duration: 1.4,
+                          ease: "easeInOut",
+                          repeat: Infinity,
+                        }}
+                      />
+                    </motion.g>
+                  </svg>
+                </motion.div>
+              )}
+
+              {phase === "flag" && (
+                <motion.div
+                  key="flag"
+                  style={{ position: "absolute", inset: 0 }}
+                  initial={{ opacity: 0, scale: 0.7 }}
+                  animate={{ opacity: 1, scale: 1 }}
+                  exit={{ opacity: 0, scale: 0.95 }}
+                  transition={{ duration: 0.35, ease: [0.34, 1.56, 0.64, 1] }}
+                >
+                  <FlagCircle locale={flagLocale} />
+                </motion.div>
+              )}
+            </AnimatePresence>
+          </div>
         </motion.div>
       )}
     </AnimatePresence>

--- a/src/components/PageLoader.tsx
+++ b/src/components/PageLoader.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { AnimatePresence, motion } from "motion/react";
+import { usePathname } from "next/navigation";
+
+export function PageLoader() {
+  const [isLoading, setIsLoading] = useState(true);
+  const pathname = usePathname();
+  const isInitialized = useRef(false);
+
+  // Hide after initial page load
+  useEffect(() => {
+    const t = setTimeout(() => {
+      setIsLoading(false);
+      isInitialized.current = true;
+    }, 1400);
+    return () => clearTimeout(t);
+  }, []);
+
+  // Show on route transitions
+  useEffect(() => {
+    if (!isInitialized.current) return;
+    setIsLoading(true);
+    const t = setTimeout(() => setIsLoading(false), 700);
+    return () => clearTimeout(t);
+  }, [pathname]);
+
+  return (
+    <AnimatePresence>
+      {isLoading && (
+        <motion.div
+          key="page-loader"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={{ duration: 0.35, ease: "easeInOut" }}
+          style={{
+            position: "fixed",
+            inset: 0,
+            zIndex: 9999,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            backgroundColor: "var(--colour-bg)",
+          }}
+        >
+          <svg
+            width="44"
+            height="44"
+            viewBox="0 0 44 44"
+            fill="none"
+            style={{ color: "var(--colour-text-primary)" }}
+          >
+            {/* Faint track */}
+            <circle
+              cx="22"
+              cy="22"
+              r="18"
+              stroke="currentColor"
+              strokeWidth="1"
+              opacity="0.12"
+            />
+            {/* Rotating arc */}
+            <motion.g
+              style={{ transformOrigin: "22px 22px" }}
+              animate={{ rotate: 360 }}
+              transition={{
+                duration: 1.4,
+                ease: "linear",
+                repeat: Infinity,
+              }}
+            >
+              <motion.circle
+                cx="22"
+                cy="22"
+                r="18"
+                stroke="currentColor"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+                initial={{ pathLength: 0.2 }}
+                animate={{ pathLength: [0.15, 0.75, 0.15] }}
+                transition={{
+                  duration: 1.4,
+                  ease: "easeInOut",
+                  repeat: Infinity,
+                }}
+              />
+            </motion.g>
+          </svg>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/src/components/PageLoader.tsx
+++ b/src/components/PageLoader.tsx
@@ -6,6 +6,11 @@ import { usePathname } from "next/navigation";
 
 type Phase = "spinner" | "flag" | "idle";
 
+// Module-level — survives React remounts, tracks locale across locale switches.
+// When the [locale] layout remounts (new dynamic segment), this lets us detect
+// that the previous locale was different from the current one.
+let prevLocaleGlobal = "";
+
 function getLocale(pathname: string): string {
   const match = pathname.match(/^\/(fr|es)(\/|$)/);
   return match ? match[1] : "en";
@@ -42,27 +47,11 @@ function FlagCircle({ locale }: { locale: string }) {
           {/* Union Jack */}
           <rect x="4" y="4" width="36" height="36" fill="#012169" />
           {/* White saltire (×) */}
-          <rect
-            x="4" y="20" width="36" height="4"
-            fill="white"
-            transform="rotate(45 22 22)"
-          />
-          <rect
-            x="4" y="20" width="36" height="4"
-            fill="white"
-            transform="rotate(-45 22 22)"
-          />
+          <rect x="4" y="20" width="36" height="4" fill="white" transform="rotate(45 22 22)" />
+          <rect x="4" y="20" width="36" height="4" fill="white" transform="rotate(-45 22 22)" />
           {/* Red saltire (×, narrower, centred) */}
-          <rect
-            x="4" y="21" width="36" height="2"
-            fill="#C8102E"
-            transform="rotate(45 22 22)"
-          />
-          <rect
-            x="4" y="21" width="36" height="2"
-            fill="#C8102E"
-            transform="rotate(-45 22 22)"
-          />
+          <rect x="4" y="21" width="36" height="2" fill="#C8102E" transform="rotate(45 22 22)" />
+          <rect x="4" y="21" width="36" height="2" fill="#C8102E" transform="rotate(-45 22 22)" />
           {/* White cross (+) */}
           <rect x="4" y="18.5" width="36" height="7" fill="white" />
           <rect x="18.5" y="4" width="7" height="36" fill="white" />
@@ -93,47 +82,56 @@ function FlagCircle({ locale }: { locale: string }) {
 }
 
 export function PageLoader() {
-  const [phase, setPhase] = useState<Phase>("spinner");
-  const [flagLocale, setFlagLocale] = useState("en");
   const pathname = usePathname();
-  const prevLocale = useRef("");
+  const locale = getLocale(pathname);
+
+  // Detect cross-locale mount at render time (before effects), using the
+  // module-level variable which persists across layout remounts.
+  const prevLocaleAtMount = prevLocaleGlobal;
+  const isCrossLocaleMount = prevLocaleAtMount !== "" && prevLocaleAtMount !== locale;
+
+  const [phase, setPhase] = useState<Phase>("spinner");
+  const [flagLocale, setFlagLocale] = useState(locale);
   const isInitialized = useRef(false);
 
-  // Initial page load — show spinner then hide
+  // Mount effect: commit global locale, run phase sequence.
   useEffect(() => {
-    prevLocale.current = getLocale(pathname);
-    const t = setTimeout(() => {
-      setPhase("idle");
-      isInitialized.current = true;
-    }, 1400);
-    return () => clearTimeout(t);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+    const savedGlobal = prevLocaleGlobal;
+    prevLocaleGlobal = locale;
 
-  // Route / locale transitions
-  useEffect(() => {
-    if (!isInitialized.current) return;
-
-    const newLocale = getLocale(pathname);
-    const isLocaleChange = prevLocale.current !== newLocale;
-    prevLocale.current = newLocale;
-
-    if (isLocaleChange) {
-      // Locale switch: spinner → flag → hide
-      setFlagLocale(newLocale);
-      setPhase("spinner");
-      const t1 = setTimeout(() => setPhase("flag"), 650);
-      const t2 = setTimeout(() => setPhase("idle"), 1250);
+    if (isCrossLocaleMount) {
+      // Locale switch: spinner → flag → idle
+      setFlagLocale(locale);
+      const t1 = setTimeout(() => setPhase("flag"), 600);
+      const t2 = setTimeout(() => {
+        setPhase("idle");
+        isInitialized.current = true;
+      }, 1350);
       return () => {
         clearTimeout(t1);
         clearTimeout(t2);
+        prevLocaleGlobal = savedGlobal; // restore for React StrictMode double-invoke
       };
     } else {
-      // Regular route change: spinner → hide
-      setPhase("spinner");
-      const t = setTimeout(() => setPhase("idle"), 700);
-      return () => clearTimeout(t);
+      // Initial load or same-locale hard navigation
+      const t = setTimeout(() => {
+        setPhase("idle");
+        isInitialized.current = true;
+      }, 1400);
+      return () => {
+        clearTimeout(t);
+        prevLocaleGlobal = savedGlobal;
+      };
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Within-locale client navigations (layout persists — pathname changes in place).
+  useEffect(() => {
+    if (!isInitialized.current) return;
+    setPhase("spinner");
+    const t = setTimeout(() => setPhase("idle"), 700);
+    return () => clearTimeout(t);
   }, [pathname]);
 
   return (
@@ -155,7 +153,7 @@ export function PageLoader() {
             backgroundColor: "var(--colour-bg)",
           }}
         >
-          {/* Fixed-size wrapper so spinner and flag can crossfade in place */}
+          {/* Fixed-size wrapper so spinner and flag crossfade in place */}
           <div style={{ position: "relative", width: 44, height: 44 }}>
             <AnimatePresence initial={false}>
               {phase === "spinner" && (


### PR DESCRIPTION
## Summary

- Adds a \`PageLoader\` client component with a minimal SVG arc animation
- Full-screen overlay fades in on initial page load (1.4s) and regular route transitions (0.7s)
- **Locale transitions** show the spinner for 650ms then crossfade to a circular flag of the destination locale (🇬🇧 EN / 🇫🇷 FR / 🇪🇸 ES) with a spring pop-in before fading out
- SVG arc rotates while morphing stroke length — elegant, non-generic feel
- Colours use \`--colour-bg\` and \`--colour-text-primary\` CSS custom properties, automatically adapting to light and dark mode
- Fixes \`next/head\` (Pages Router API) replaced with App Router \`export const viewport: Viewport\`

## Test plan

- [ ] Loader appears on initial page load and fades out cleanly
- [ ] Regular route transitions show spinner only (0.7s)
- [ ] Locale switch (EN → FR → ES): spinner → circular flag → fade out
- [ ] Correct flag shown per locale: Union Jack (EN), tricolour (FR), red/yellow stripes (ES)
- [ ] Light mode: off-white background (\`#f2f3f4\`) with dark arc (\`#243849\`)
- [ ] Dark mode: dark background (\`#14161b\`) with white arc (\`#fff\`)
- [ ] No flash of unstyled content or layout shift after loader dismisses

## Loader phases

**Initial load / regular route change** — spinning arc, fades out after 1.4s / 0.7s

**Locale switch** — three-stage sequence:
1. Spinner arc (650ms)
2. Circular flag pops in with spring easing (holds for ~600ms)  
3. Full overlay fades out

**Flags** — all clipped to a circle matching the spinner radius (r=18), layered over the same faint track ring:

| Locale | Flag |
|--------|------|
| `en`   | Union Jack (`#012169` / `#C8102E` / white) |
| `fr`   | French tricolour (`#002395` / white / `#ED2939`) |
| `es`   | Spanish flag (`#AA151B` / `#F1BF00`) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)