### PR TITLE
fix: prevent scroll-to-top on locale switch

### DIFF
--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -168,17 +168,17 @@ export default function Home() {
       >
         <ul className="flex items-center justify-center gap-10">
           <li>
-            <Link href="/" locale="en">
+            <Link href="/" locale="en" scroll={false}>
               English
             </Link>
           </li>
           <li>
-            <Link href="/" locale="fr">
+            <Link href="/" locale="fr" scroll={false}>
               Français
             </Link>
           </li>
           <li>
-            <Link href="/" locale="es">
+            <Link href="/" locale="es" scroll={false}>
               Español
             </Link>
           </li>


### PR DESCRIPTION
Add scroll={false} to locale Link components so the page position is preserved when the loader takes over during a locale change.