### PR TITLE
fix: restore spinner rotation by using fill-box transform origin

### DIFF
--- a/src/components/PageLoader.tsx
+++ b/src/components/PageLoader.tsx
@@ -217,7 +217,7 @@ export function PageLoader() {
                       opacity="0.12"
                     />
                     <motion.g
-                      style={{ transformOrigin: "22px 22px" }}
+                      style={{ transformBox: "fill-box", transformOrigin: "50% 50%" }}
                       animate={{ rotate: 360 }}
                       transition={{
                         duration: 1.4,


### PR DESCRIPTION
CSS transform-origin with px values is unreliable on SVG elements. Switch to transformBox: fill-box + transformOrigin: 50% 50% so Framer Motion's rotate animation correctly pivots around the circle centre.